### PR TITLE
Fix existing name map creating

### DIFF
--- a/css/styling.css
+++ b/css/styling.css
@@ -15,7 +15,7 @@ button {
     margin-bottom: 5px;
 }
 
-.lang-div h1 {
+.probability-div h1 {
     margin: 0;
 }
 
@@ -34,7 +34,7 @@ button {
     max-height: 60vh;
 }
 
-.lang-label {
+.probability-label {
     font-size: 30px;
 }
 
@@ -42,7 +42,7 @@ button {
     font-size: 15px;
 }
 
-.lang-header {
+.probability-header {
     padding-top: 10px;
     padding-bottom: 10px;
 }
@@ -57,5 +57,6 @@ button {
 
 .no-bullets {
     list-style-type: none;
+    font-size: 20px;
 }
 

--- a/src/webapp/name_generator.js
+++ b/src/webapp/name_generator.js
@@ -22,7 +22,6 @@ function generateNames(numberOfNames) {
             attempt++;
         } while (!checkNameValidity(genName) && attempt <= maxTries || uniqueList.includes(genName))
         uniqueList.push(genName);
-        console.log(genName);
             
         nameList.insertAdjacentHTML("afterbegin", "<li>" + genName + "</li>");
     }

--- a/src/webapp/name_generator.js
+++ b/src/webapp/name_generator.js
@@ -22,6 +22,7 @@ function generateNames(numberOfNames) {
             attempt++;
         } while (!checkNameValidity(genName) && attempt <= maxTries || uniqueList.includes(genName))
         uniqueList.push(genName);
+        console.log(genName);
             
         nameList.insertAdjacentHTML("afterbegin", "<li>" + genName + "</li>");
     }
@@ -51,7 +52,8 @@ function checkNameValidity(generatedName){
         }
     }
 
-    if (currentMap.has(" ")) {
+    if (currentMap.has("end")) {
+        // The generated name already exists in the base list
         return false;
     }
 

--- a/src/webapp/probability_generator.html
+++ b/src/webapp/probability_generator.html
@@ -6,11 +6,11 @@
 
   <body>
     
-    <div class="lang-div">
-      <h1 class="lang-header">Language Base</h1>
+    <div class="probability-div">
+      <h1 class="probability-header">Base List</h1>
 
       <div>
-        <label class="lang-label" for="probability_lists">Select a list from which you would like to generate names</label><br>
+        <label class="probability-label" for="probability_lists">Select a list from which you would like to generate names</label><br>
         <select class="select-list" name="probability_lists" id="probability_lists">
           <option value="nothing">Nothing selected</option>
           <option value="top400">Top 400 baby names 2010s</option>
@@ -27,7 +27,7 @@
       </div>
 
       <div>
-        <label class="lang-label" id="userListAlert">Name probabilities have been generated from: No file selected</label><br>
+        <label class="probability-label" id="userListAlert">Name probabilities have been generated from: No file selected</label><br>
       </div>
 
     </div>

--- a/src/webapp/probability_generator.js
+++ b/src/webapp/probability_generator.js
@@ -134,7 +134,7 @@ function addNameToExistingNames(nameToAdd) {
         }
     }
     // Set a final entry for this letter indicating that this end is a valid name
-    currentMap.set(" ", "");
+    currentMap.set("end", "");
 }
 
 function createAlphabet(listOfNames) {


### PR DESCRIPTION
An error occurred when there were names along the lines of "James" and "James I" if the first one was read in first. Since we were adding a " " to the end of "James" without a map attached to it, and "James I" has a " " in it and then more. It would try and access the map after " " but get an error because there was no map.
Since we have added an alphabet generator that could have " " as a valid character, I have make the end of a name in the map be "end" to clear up some of the confusion as to when a name has a valid ending.

Make generated names font a bit bigger so its easier to see against the mountains.

Change some naming of html elements to be more consistent. Both on the user side and just on the code side.